### PR TITLE
chore(db): unify UUID PKs and add reliability/consistency features

### DIFF
--- a/prisma/migrations/20250904112600_project_name_unique_and_user_password_nullable/migration.sql
+++ b/prisma/migrations/20250904112600_project_name_unique_and_user_password_nullable/migration.sql
@@ -1,0 +1,169 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `created_at` on the `github` table. All the data in the column will be lost.
+  - You are about to drop the column `installation_id` on the `github` table. All the data in the column will be lost.
+  - You are about to drop the column `updated_at` on the `github` table. All the data in the column will be lost.
+  - You are about to drop the `project_repositories` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[github_id]` on the table `github` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[job_id,dedupe_key]` on the table `job_errors` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[idempotency_key]` on the table `pipeline_runs` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[project_id,name,version]` on the table `pipelines` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[user_id,name]` on the table `projects` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `github_id` to the `github` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."project_repositories" DROP CONSTRAINT "project_repositories_project_id_fkey";
+
+-- DropIndex
+DROP INDEX "public"."github_installation_id_key";
+
+-- DropIndex
+DROP INDEX "public"."job_errors_dedupe_key_key";
+
+-- DropIndex
+DROP INDEX "public"."job_errors_occurred_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."job_status_events_job_id_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."jobs_run_id_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."jobs_status_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."jobs_type_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."logs_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."pipeline_runs_pipeline_id_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."pipeline_runs_status_created_at_idx";
+
+-- DropIndex
+DROP INDEX "public"."pipelines_name_version_key";
+
+-- AlterTable
+ALTER TABLE "public"."github" DROP COLUMN "created_at",
+DROP COLUMN "installation_id",
+DROP COLUMN "updated_at",
+ADD COLUMN     "github_id" TEXT NOT NULL,
+ALTER COLUMN "access_token" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."pipeline_runs" ADD COLUMN     "idempotency_key" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."pipelines" ADD COLUMN     "normalized_spec" JSONB,
+ADD COLUMN     "original_spec" TEXT,
+ADD COLUMN     "spec_hash" VARCHAR(64);
+
+-- AlterTable
+ALTER TABLE "public"."refresh_tokens" ALTER COLUMN "expires_at" SET DATA TYPE TIMESTAMPTZ(6),
+ALTER COLUMN "last_used_at" SET DATA TYPE TIMESTAMPTZ(6),
+ALTER COLUMN "created_at" SET DATA TYPE TIMESTAMPTZ(6);
+
+-- AlterTable
+ALTER TABLE "public"."users" ALTER COLUMN "password" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "public"."project_repositories";
+
+-- CreateTable
+CREATE TABLE "public"."outbox" (
+    "id" BIGSERIAL NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "published_at" TIMESTAMPTZ(6),
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "outbox_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "outbox_published_at_idx" ON "public"."outbox"("published_at");
+
+-- CreateIndex
+CREATE INDEX "outbox_created_at_idx" ON "public"."outbox"("created_at");
+
+-- CreateIndex
+CREATE INDEX "environments_project_id_idx" ON "public"."environments"("project_id");
+
+-- CreateIndex
+CREATE INDEX "environments_created_at_idx" ON "public"."environments"("created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "github_github_id_key" ON "public"."github"("github_id");
+
+-- CreateIndex
+CREATE INDEX "job_errors_occurred_at_idx" ON "public"."job_errors"("occurred_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "job_errors_job_id_dedupe_key_key" ON "public"."job_errors"("job_id", "dedupe_key");
+
+-- CreateIndex
+CREATE INDEX "job_status_events_job_id_at_idx" ON "public"."job_status_events"("job_id", "at");
+
+-- CreateIndex
+CREATE INDEX "jobs_run_id_created_at_idx" ON "public"."jobs"("run_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "jobs_status_created_at_idx" ON "public"."jobs"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "jobs_type_created_at_idx" ON "public"."jobs"("type", "created_at");
+
+-- CreateIndex
+CREATE INDEX "jobs_created_at_idx" ON "public"."jobs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "logs_created_at_idx" ON "public"."logs"("created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pipeline_runs_idempotency_key_key" ON "public"."pipeline_runs"("idempotency_key");
+
+-- CreateIndex
+CREATE INDEX "pipeline_runs_pipeline_id_created_at_idx" ON "public"."pipeline_runs"("pipeline_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "pipeline_runs_status_created_at_idx" ON "public"."pipeline_runs"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "pipeline_runs_created_at_idx" ON "public"."pipeline_runs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "pipelines_spec_hash_idx" ON "public"."pipelines"("spec_hash");
+
+-- CreateIndex
+CREATE INDEX "pipelines_created_at_idx" ON "public"."pipelines"("created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pipelines_project_id_name_version_key" ON "public"."pipelines"("project_id", "name", "version");
+
+-- CreateIndex
+CREATE INDEX "projects_user_id_idx" ON "public"."projects"("user_id");
+
+-- CreateIndex
+CREATE INDEX "projects_created_at_idx" ON "public"."projects"("created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "projects_user_id_name_key" ON "public"."projects"("user_id", "name");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_user_id_idx" ON "public"."refresh_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_expires_at_idx" ON "public"."refresh_tokens"("expires_at");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_created_at_idx" ON "public"."refresh_tokens"("created_at");
+
+-- CreateIndex
+CREATE INDEX "users_created_at_idx" ON "public"."users"("created_at");

--- a/prisma/migrations/20250904190731_unify_uuid_add_outbox_pipeline_spec_githubinstallation/migration.sql
+++ b/prisma/migrations/20250904190731_unify_uuid_add_outbox_pipeline_spec_githubinstallation/migration.sql
@@ -1,0 +1,69 @@
+/*
+  Warnings:
+
+  - You are about to drop the `github` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."github" DROP CONSTRAINT "github_user_id_fkey";
+
+-- DropTable
+DROP TABLE "public"."github";
+
+-- CreateTable
+CREATE TABLE "public"."github_installations" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "installation_id" TEXT NOT NULL,
+    "account_login" TEXT,
+    "account_id" BIGINT,
+    "access_token" TEXT,
+    "token_expires_at" TIMESTAMPTZ(6),
+    "last_issued_at" TIMESTAMPTZ(6),
+    "last_used_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "github_installations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."project_repositories" (
+    "id" UUID NOT NULL,
+    "project_id" UUID NOT NULL,
+    "repo_full_name" TEXT NOT NULL,
+    "selected_branch" TEXT NOT NULL,
+    "installation_id" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "project_repositories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "github_installations_installation_id_key" ON "public"."github_installations"("installation_id");
+
+-- CreateIndex
+CREATE INDEX "github_installations_user_id_idx" ON "public"."github_installations"("user_id");
+
+-- CreateIndex
+CREATE INDEX "github_installations_account_login_idx" ON "public"."github_installations"("account_login");
+
+-- CreateIndex
+CREATE INDEX "github_installations_account_id_idx" ON "public"."github_installations"("account_id");
+
+-- CreateIndex
+CREATE INDEX "project_repositories_project_id_idx" ON "public"."project_repositories"("project_id");
+
+-- CreateIndex
+CREATE INDEX "project_repositories_installation_id_idx" ON "public"."project_repositories"("installation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_repositories_project_id_repo_full_name_key" ON "public"."project_repositories"("project_id", "repo_full_name");
+
+-- AddForeignKey
+ALTER TABLE "public"."github_installations" ADD CONSTRAINT "github_installations_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."project_repositories" ADD CONSTRAINT "project_repositories_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("project_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,56 +1,52 @@
-// ---------------------------------------------
 // Database: PostgreSQL
-// 주요 기능: 사용자 인증, GitHub 연동, 프로젝트/환경/파이프라인/실행/작업/로그 관리, Outbox 발행
-// 설계 원칙 (2025-09-04 갱신):
-//   - 모든 ID는 UUID(v4) 사용 (단순성/호환성)
-//   - 시간 순 정렬은 created_at + 인덱스로 처리 (DESC 인덱스는 Raw SQL로만 필요 시 추가)
-//   - 파이프라인 스펙: 원본(original)·정규화(normalized)·해시(specHash=canonical JSON → SHA-256) 모두 보관
-//   - Outbox + IdempotencyKey로 발행 신뢰성/멱등성 확보
-//   - FK 타입은 모두 일관되게 @db.Uuid
-//   - Logs 테이블은 포인터 1행 정책(대용량 본문은 외부 스토리지/스트리밍)
-//   - 프로젝트 이름은 같은 사용자(userID) 내에서 유일(@@unique([userID, name]))
-//   - OAuth(GitHub) 계정은 password 필드 NULL 허용(User.password: String?)
-// ---------------------------------------------
+// 목적: 사용자/프로젝트/파이프라인/실행/작업/로그/오류 + GitHub App 설치/레포 연결 관리
+// 갱신 일자: 25.09.05 (v3)
+// 설계 원칙:
+//   - 모든 PK/FK: UUID(v4)
+//   - 시간 정렬: created_at + 인덱스
+//   - 파이프라인 스펙: original_spec / normalized_spec / spec_hash 보관 (canonical JSON → SHA-256)
+//   - 멱등성: pipeline_runs.idempotency_key(unique) + 필요 시 Outbox 패턴
+//   - GitHub App: installationId 저장, accessToken? 는 확인 용도로만 보류
+//   - 프로젝트↔레포 연결(ProjectRepository) 유지
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["relationJoins"]
+  binaryTargets   = ["native", "debian-openssl-3.0.x"] // ← 수정: ubuntu/debian x64
 }
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL") // .env 파일의 DB 연결 문자열 사용
+  url      = env("DATABASE_URL")
 }
 
-// -----------------------------
-// Enums: 역할, 언어, 환경, Job/Log 상태 정의
-// -----------------------------
-
-// RBAC: 사용자 역할
+// 공용 enum
+// 사용자 역할 정의 (RBAC: 역할 기반 접근 제어)
 enum MemberRole {
-  ADMIN
-  MEMBER
-  VIEWER
+  ADMIN // 관리자: 모든 권한
+  MEMBER // 일반 사용자: 기본 권한
+  VIEWER // 읽기 전용: 제한된 권한
 }
 
-// 지원 언어
+// 지원 언어 정의 (MVP: Node, Python)
 enum Language {
-  NODE
-  PYTHON
+  NODE // Node.js 환경
+  PYTHON // Python 환경
 }
 
-// MVP 배포 환경
+// 지원 배포 환경 정의 (MVP: EC2)
 enum DeployEnvironment {
-  EC2
+  EC2 // AWS EC2 인스턴스
 }
 
-// 작업 타입
+// 작업 타입 정의 (빌드/테스트/배포 작업 구분)
 enum JobType {
-  BUILD
-  TEST
-  DEPLOYMENT
+  BUILD // 빌드 작업
+  TEST // 테스트 작업 (Unit/E2E)
+  DEPLOYMENT // 배포 작업
 }
 
-// 작업 상태 라이프사이클
+// 작업 상태 정의 (작업 라이프사이클 관리, 재시도 상태 포함)
 enum JobStatus {
   pending
   running
@@ -59,44 +55,41 @@ enum JobStatus {
   cancelled
 }
 
-// 로그 스트림
+// 로그 스트림 정의 (stdout/stderr 구분, S3 연계 시 사용)
 enum LogStream {
-  stdout
-  stderr
+  stdout // 표준 출력
+  stderr // 표준 에러
 }
 
-// 테스트 세분화
+// 테스트 타입 정의 (테스트 작업 세분화)
 enum TestType {
-  UNIT
-  E2E
+  UNIT // 단위 테스트
+  E2E // End-to-End 테스트
 }
 
-// -----------------------------
-// Models
-// -----------------------------
-
+// 사용자 정보: 인증 및 프로젝트 소유
 model User {
-  userID     String     @id @default(uuid()) @map("user_id") @db.Uuid // UUID 기본키
-  email      String     @unique @map("email") // 로그인 식별자
-  password   String?    @map("password") // bcrypt 해시 저장, GitHub 계정은 NULL 허용
-  name       String     @map("name") // 표시 이름
-  memberRole MemberRole @default(MEMBER) @map("member_role") // 역할
-  createdAt  DateTime   @default(now()) @map("created_at") @db.Timestamptz(6) // 생성일
-  updatedAt  DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정일
+  userID     String     @id @default(uuid()) @map("user_id") @db.Uuid
+  email      String     @unique @map("email")
+  password   String?    @map("password") // OAuth-only 계정 허용
+  name       String     @map("name")
+  memberRole MemberRole @default(MEMBER) @map("member_role")
+  createdAt  DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  // Relations
   projects      Project[]
-  github        Github?
+  installations GithubInstallation[]
   refreshTokens RefreshToken[]
 
-  @@index([createdAt]) // 최근 사용자 조회
+  @@index([createdAt])
   @@map("users")
 }
 
+// Refresh Token
 model RefreshToken {
   tokenId    String   @id @default(uuid()) @map("token_id") @db.Uuid
   userID     String   @map("user_id") @db.Uuid
-  token      String   @unique @map("token") // 리프레시 토큰 값
+  token      String   @unique @map("token")
   expiresAt  DateTime @map("expires_at") @db.Timestamptz(6)
   lastUsedAt DateTime @default(now()) @map("last_used_at") @db.Timestamptz(6)
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -109,44 +102,80 @@ model RefreshToken {
   @@map("refresh_tokens")
 }
 
-model Github {
-  userID      String  @id @map("user_id") @db.Uuid
-  githubID    String  @unique @map("github_id") // GitHub 계정 고유 ID
-  accessToken String? @map("access_token") // 선택적 토큰
+// GitHub App 설치 (User:Installation = 1:N)
+model GithubInstallation {
+  id             String  @id @default(uuid()) @map("id") @db.Uuid
+  userID         String  @map("user_id") @db.Uuid
+  installationId String  @unique @map("installation_id") // GitHub 설치 고유 ID
+  accountLogin   String? @map("account_login") // 소유자 login (user/org)
+  accountId      BigInt? @map("account_id") @db.BigInt // 소유자 numeric ID
+
+  // ⚠ 운영 원칙: 설치 토큰은 DB 미저장(재발급/캐시 권장). 아래 컬럼은 확인 목적의 보류용.
+  accessToken    String?   @map("access_token") // 확인 필요: 운영 저장 금지 권장
+  tokenExpiresAt DateTime? @map("token_expires_at") @db.Timestamptz(6)
+  lastIssuedAt   DateTime? @map("last_issued_at") @db.Timestamptz(6)
+  lastUsedAt     DateTime? @map("last_used_at") @db.Timestamptz(6)
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   user User @relation(fields: [userID], references: [userID], onDelete: Cascade)
 
-  @@map("github")
+  @@index([userID])
+  @@index([accountLogin])
+  @@index([accountId])
+  @@map("github_installations")
 }
 
+// 프로젝트: 사용자별 CI/CD 작업 단위
 model Project {
-  projectID  String   @id @default(uuid()) @map("project_id") @db.Uuid // 프로젝트 ID (UUID)
-  userID     String   @map("user_id") @db.Uuid // 소유 사용자 ID (FK)
-  name       String   @map("name") // 프로젝트명 (사용자별 유일)
-  webhookUrl String?  @unique @map("webhook_url") // GitHub webhook (전역 유일, NULL 허용)
-  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정 시각
+  projectID  String   @id @default(uuid()) @map("project_id") @db.Uuid
+  userID     String   @map("user_id") @db.Uuid // 소유자 ID
+  name       String   @map("name") // 프로젝트 표시 이름
+  webhookUrl String?  @unique @map("webhook_url")
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  // Relations
-  user         User          @relation(fields: [userID], references: [userID], onDelete: Cascade) // 사용자 삭제 시 연쇄 삭제
-  pipelines    Pipeline[] // 프로젝트에 속한 파이프라인들
-  environments Environment[] // 프로젝트 환경들
+  user         User                @relation(fields: [userID], references: [userID], onDelete: Cascade)
+  pipelines    Pipeline[]
+  environments Environment[]
+  repositories ProjectRepository[]
 
-  @@unique([userID, name]) // 같은 사용자 내 동일 이름 금지(GitHub 리포지토리 네이밍과 유사 규칙)
-  @@index([userID]) // 사용자별 프로젝트 조회 최적화
-  @@index([createdAt]) // 최신순 정렬/조회 최적화
+  @@unique([userID, name]) // 동일 사용자 내 프로젝트명 유일
+  @@index([userID])
+  @@index([createdAt])
   @@map("projects")
 }
 
+// 프로젝트 ↔ 레포 연결
+model ProjectRepository {
+  id             String   @id @default(uuid()) @map("id") @db.Uuid
+  projectID      String   @map("project_id") @db.Uuid
+  repoFullName   String   @map("repo_full_name") // owner/repo
+  selectedBranch String   @map("selected_branch") // 대상 브랜치
+  installationId String?  @map("installation_id") // 사용 설치 선택(다중 설치 대비)
+  isActive       Boolean  @default(true) @map("is_active")
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  project Project @relation(fields: [projectID], references: [projectID], onDelete: Cascade)
+
+  @@unique([projectID, repoFullName]) // 동일 프로젝트-레포 중복 연결 방지
+  @@index([projectID])
+  @@index([installationId])
+  @@map("project_repositories")
+}
+
+// 환경 설정: 언어, 배포 환경, 환경 변수, 인증 정보
 model Environment {
   environmentID    String            @id @default(uuid()) @map("environment_id") @db.Uuid
-  projectID        String            @map("project_id") @db.Uuid
-  language         Language          @map("language")
-  deployEnv        DeployEnvironment @map("deploy_environment")
-  envVariables     Json?             @map("env_variables")
-  credentials      Json?             @map("credentials")
-  deploymentTarget String?           @map("deployment_target")
-  deploymentPath   String?           @map("deployment_path")
+  projectID        String            @map("project_id") @db.Uuid // 소속 프로젝트 ID
+  language         Language          @map("language") // 프로그래밍 언어 (Node/Python)
+  deployEnv        DeployEnvironment @map("deploy_environment") // 배포 환경 (EC2)
+  envVariables     Json?             @map("env_variables") // 런타임/빌드용 ENV
+  credentials      Json?             @map("credentials") // 자격/접속 정보(암호화 전제)
+  deploymentTarget String?           @map("deployment_target") // 대상 호스트/도메인
+  deploymentPath   String?           @map("deployment_path") // 원격 경로
   servicePort      Int?              @map("service_port")
   createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
@@ -158,50 +187,52 @@ model Environment {
   @@map("environments")
 }
 
+// 파이프라인 정의: 빌드/테스트/배포 워크플로우 정의
 model Pipeline {
   pipelineID     String   @id @default(uuid()) @map("pipeline_id") @db.Uuid
-  projectID      String   @map("project_id") @db.Uuid
-  name           String   @map("name")
-  version        Int      @default(1) @map("version") // 버전 관리
-  active         Boolean  @default(true) @map("active")
-  owner          String?  @map("owner")
-  pipelineSpec   Json     @map("pipeline_spec") // 원본 pipeline JSON
+  projectID      String   @map("project_id") @db.Uuid // 소속 프로젝트 ID
+  name           String   @map("name") // 파이프라인 이름
+  version        Int      @default(1) @map("version") // 버전 관리, 기본 1
+  active         Boolean  @default(true) @map("active") // 활성 여부
+  owner          String?  @map("owner") // 소유자 정보 (선택적, 사용자 이름/ID)
+  pipelineSpec   Json     @map("pipeline_spec")
   isBlockBased   Boolean  @default(false) @map("is_block_based")
-  originalSpec   String?  @map("original_spec") @db.Text // 원본 YAML/JSON 저장
-  normalizedSpec Json?    @map("normalized_spec") // 정규화된 JSON
-  specHash       String?  @map("spec_hash") @db.VarChar(64) // SHA-256 해시
+  originalSpec   String?  @map("original_spec") @db.Text // 원본 YAML/JSON
+  normalizedSpec Json?    @map("normalized_spec") // canonical JSON
+  specHash       String?  @map("spec_hash") @db.VarChar(64) // SHA-256
   createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   project Project       @relation(fields: [projectID], references: [projectID], onDelete: Cascade)
   runs    PipelineRun[]
 
-  @@unique([projectID, name, version])
+  @@unique([projectID, name, version]) // 프로젝트별 버전 유일
   @@index([owner])
   @@index([projectID])
-  @@index([specHash])
   @@index([createdAt])
+  @@index([specHash])
   @@map("pipelines")
 }
 
+// 파이프라인 실행 인스턴스: 특정 시점의 파이프라인 실행
 model PipelineRun {
   id              String    @id @default(uuid()) @map("id") @db.Uuid
-  pipelineID      String    @map("pipeline_id") @db.Uuid
-  pipelineVersion Int       @map("pipeline_version")
-  status          JobStatus @map("status")
+  pipelineID      String    @map("pipeline_id") @db.Uuid // 소속 파이프라인 ID
+  pipelineVersion Int       @map("pipeline_version") // 실행 시점의 파이프라인 버전
+  status          JobStatus @map("status") // 실행 상태
   createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   queuedAt        DateTime? @map("queued_at") @db.Timestamptz(6)
   startedAt       DateTime? @map("started_at") @db.Timestamptz(6)
   finishedAt      DateTime? @map("finished_at") @db.Timestamptz(6)
-  exitCode        Int?      @map("exit_code")
-  owner           String?   @map("owner")
-  agent           String?   @map("agent")
-  containerImage  String?   @map("container_image")
-  trigger         String?   @map("trigger")
-  labels          Json?     @map("labels")
-  metadata        Json?     @map("metadata")
-  externalRunKey  String?   @unique @map("external_run_key")
-  idempotencyKey  String?   @unique @map("idempotency_key") // 멱등성 보장
+  exitCode        Int?      @map("exit_code") // 종료 코드 (오류 분석)
+  owner           String?   @map("owner") // 실행 요청자
+  agent           String?   @map("agent") // 실행 에이전트 (서버/컨테이너)
+  containerImage  String?   @map("container_image") // 컨테이너 이미지
+  trigger         String?   @map("trigger") // webhook/manual 등
+  labels          Json?     @map("labels") // 레이블 (메타데이터)
+  metadata        Json?     @map("metadata") // 추가 메타데이터
+  externalRunKey  String?   @unique @map("external_run_key") // 외부 실행 키 (고유)
+  idempotencyKey  String?   @unique @map("idempotency_key") // 요청 멱등키
 
   pipeline Pipeline @relation(fields: [pipelineID], references: [pipelineID], onDelete: Restrict)
   jobs     Job[]
@@ -212,37 +243,38 @@ model PipelineRun {
   @@map("pipeline_runs")
 }
 
+// 개별 작업: 빌드/테스트/배포 등 구체적 작업 단위
 model Job {
   id             String    @id @default(uuid()) @map("id") @db.Uuid
-  runID          String    @map("run_id") @db.Uuid
-  name           String    @map("name")
-  type           JobType   @map("type")
-  testType       TestType? @map("test_type")
-  status         JobStatus @map("status")
-  attemptCurrent Int       @default(0) @map("attempt_current")
-  attemptMax     Int       @default(3) @map("attempt_max")
-  exitCode       Int?      @map("exit_code")
-  envVariables   Json?     @map("env_variables")
-  s3ArtifactUrl  String?   @map("s3_artifact_url")
-  targetUrl      String?   @map("target_url")
+  runID          String    @map("run_id") @db.Uuid // 소속 실행 ID
+  name           String    @map("name") // 작업 이름
+  type           JobType   @map("type") // 작업 타입 (BUILD/TEST/DEPLOYMENT)
+  testType       TestType? @map("test_type") // 테스트 타입 (TEST일 때 사용)
+  status         JobStatus @map("status") // 작업 상태 (재시도 상태 포함)
+  attemptCurrent Int       @default(0) @map("attempt_current") // 현재 재시도 횟수
+  attemptMax     Int       @default(3) @map("attempt_max") // 최대 재시도 횟수
+  exitCode       Int?      @map("exit_code") // 종료 코드
+  envVariables   Json?     @map("env_variables") // 작업별 환경 변수 (런타임 주입)
+  s3ArtifactUrl  String?   @map("s3_artifact_url") // S3 결과물 URL
+  targetUrl      String?   @map("target_url") // 배포 대상 URL (DEPLOYMENT용)
   createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   queuedAt       DateTime? @map("queued_at") @db.Timestamptz(6)
   startedAt      DateTime? @map("started_at") @db.Timestamptz(6)
   finishedAt     DateTime? @map("finished_at") @db.Timestamptz(6)
-  owner          String?   @map("owner")
-  agent          String?   @map("agent")
-  containerImage String?   @map("container_image")
-  command        String?   @map("command")
-  inputs         Json?     @map("inputs")
-  outputs        Json?     @map("outputs")
-  externalJobKey String?   @unique @map("external_job_key")
+  owner          String?   @map("owner") // 소유자
+  agent          String?   @map("agent") // 에이전트
+  containerImage String?   @map("container_image") // 컨테이너 이미지
+  command        String?   @map("command") // 실행 명령어
+  inputs         Json?     @map("inputs") // 입력 데이터
+  outputs        Json?     @map("outputs") // 출력 결과
+  externalJobKey String?   @unique @map("external_job_key") // 외부 작업 키
 
   run          PipelineRun      @relation(fields: [runID], references: [id], onDelete: Cascade)
   statusEvents JobStatusEvent[]
   errors       JobError[]
   logs         Log[]
 
-  @@unique([runID, name])
+  @@unique([runID, name]) // 실행 내 작업명 유일
   @@index([runID, createdAt])
   @@index([status, createdAt])
   @@index([type, createdAt])
@@ -251,13 +283,14 @@ model Job {
   @@map("jobs")
 }
 
+// 작업 상태 이벤트: 상태 변화 추적
 model JobStatusEvent {
   id         String     @id @default(uuid()) @map("id") @db.Uuid
-  jobID      String     @map("job_id") @db.Uuid
-  fromStatus JobStatus? @map("from_status")
-  toStatus   JobStatus  @map("to_status")
-  reason     String?    @map("reason")
-  data       Json?      @map("data")
+  jobID      String     @map("job_id") @db.Uuid // 소속 작업 ID
+  fromStatus JobStatus? @map("from_status") // 이전 상태 (선택적)
+  toStatus   JobStatus  @map("to_status") // 현재 상태
+  reason     String?    @map("reason") // 상태 변경 사유
+  data       Json?      @map("data") // 추가 데이터
   at         DateTime   @default(now()) @map("at") @db.Timestamptz(6)
 
   job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
@@ -266,55 +299,60 @@ model JobStatusEvent {
   @@map("job_status_events")
 }
 
+// 작업 오류: 실행 중 발생한 오류 기록
 model JobError {
   id         String   @id @default(uuid()) @map("id") @db.Uuid
-  jobID      String   @map("job_id") @db.Uuid
-  attemptNo  Int      @map("attempt_no")
+  jobID      String   @map("job_id") @db.Uuid // 소속 작업 ID
+  attemptNo  Int      @map("attempt_no") // 재시도 번호
   occurredAt DateTime @default(now()) @map("occurred_at") @db.Timestamptz(6)
-  errorType  String?  @map("error_type")
-  message    String?  @map("message") @db.VarChar(4096)
-  stacktrace String?  @map("stacktrace") @db.VarChar(8192)
+  errorType  String?  @map("error_type") // 오류 유형
+  message    String?  @map("message") @db.VarChar(4096) // 오류 메시지
+  stacktrace String?  @map("stacktrace") @db.VarChar(8192) // 스택 트레이스
   context    Json?    @map("context")
-  dedupeKey  String?  @map("dedupe_key")
+  dedupeKey  String?  @map("dedupe_key") // 동일 작업 내 중복 에러 제거
 
   job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
 
-  @@unique([jobID, dedupeKey]) // Job별 오류 중복 제거
+  @@unique([jobID, dedupeKey]) // 작업 단위 중복 방지
   @@index([jobID, attemptNo])
   @@index([occurredAt])
   @@index([errorType])
   @@map("job_errors")
 }
 
+// 로그 (1행 포인터: 대용량은 외부 스토리지)
 model Log {
   logID         String    @id @default(uuid()) @map("log_id") @db.Uuid
-  jobID         String    @map("job_id") @db.Uuid
-  attemptNo     Int       @map("attempt_no")
-  stream        LogStream @map("stream")
-  content       String?   @map("content") // 짧은 로그만 저장
-  storageBucket String?   @map("storage_bucket") // S3 버킷
+  jobID         String    @map("job_id") @db.Uuid // 소속 작업 ID
+  attemptNo     Int       @map("attempt_no") // 재시도 번호
+  stream        LogStream @map("stream") // 로그 스트림 (stdout/stderr)
+  content       String?   @map("content") // 내부 로그 내용 (짧은 로그)
+  storageBucket String?   @map("storage_bucket") // S3 버킷 (긴 로그)
   storageKey    String?   @map("storage_key") // S3 키
-  sizeBytes     BigInt?   @map("size_bytes") @db.BigInt
-  contentType   String?   @map("content_type")
+  sizeBytes     BigInt?   @map("size_bytes") @db.BigInt // 로그 크기 (바이트)
+  contentType   String?   @map("content_type") // 콘텐츠 타입 (e.g., text/plain)
   createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
 
   job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
 
-  @@unique([jobID, attemptNo, stream]) // Job/시도/스트림별 1행만
+  @@unique([jobID, attemptNo, stream]) // 동일 시도/스트림 1행
   @@index([jobID, attemptNo])
   @@index([createdAt])
   @@map("logs")
 }
 
+// Outbox 패턴: 트랜잭션 내 이벤트를 안전하게 발행하기 위한 테이블
+// DB commit 성공 이후 별도 프로세스가 읽어 외부 시스템(Kafka, Redis, S3 등)에 전달
+// API → DB 기록 → Outbox → 비동기 발행 으로 데이터 유실 방지
 model Outbox {
   id          BigInt    @id @default(autoincrement()) @map("id")
-  eventType   String    @map("event_type") // 이벤트 타입
-  payload     Json      @map("payload") // 이벤트 본문
+  eventType   String    @map("event_type") // 이벤트 유형 (예: JOB_CREATED, PIPELINE_RUN_FINISHED)
+  payload     Json      @map("payload") // 이벤트 본문 (JSON 직렬화된 데이터)
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  publishedAt DateTime? @map("published_at") @db.Timestamptz(6) // 발행 시각
-  attempts    Int       @default(0) @map("attempts") // 재시도 횟수
+  publishedAt DateTime? @map("published_at") @db.Timestamptz(6) // 외부 발행 시각 (NULL이면 미발행 상태)
+  attempts    Int       @default(0) @map("attempts") // 발행 시도 횟수 (재시도 로직에 사용)
 
-  @@index([publishedAt])
   @@index([createdAt])
+  @@index([publishedAt])
   @@map("outbox")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,313 +1,320 @@
-// 데이터베이스: PostgreSQL
-// 주요 기능: 사용자 인증, GitHub 연동, 프로젝트 관리, 환경 설정, 파이프라인, 실행, 작업, 로그, 상태/오류 관리
-// 설계 원칙: Job/Log ID는 ULID (커스텀 함수), 나머지 UUID, 타임스탬프 정밀도 일관, 계층 구조 활용, JSON으로 확장성
+// ---------------------------------------------
+// Database: PostgreSQL
+// 주요 기능: 사용자 인증, GitHub 연동, 프로젝트/환경/파이프라인/실행/작업/로그 관리, Outbox 발행
+// 설계 원칙 (2025-09-04 갱신):
+//   - 모든 ID는 UUID(v4) 사용 (단순성/호환성)
+//   - 시간 순 정렬은 created_at + 인덱스로 처리 (DESC 인덱스는 Raw SQL로만 필요 시 추가)
+//   - 파이프라인 스펙: 원본(original)·정규화(normalized)·해시(specHash=canonical JSON → SHA-256) 모두 보관
+//   - Outbox + IdempotencyKey로 발행 신뢰성/멱등성 확보
+//   - FK 타입은 모두 일관되게 @db.Uuid
+//   - Logs 테이블은 포인터 1행 정책(대용량 본문은 외부 스토리지/스트리밍)
+//   - 프로젝트 이름은 같은 사용자(userID) 내에서 유일(@@unique([userID, name]))
+//   - OAuth(GitHub) 계정은 password 필드 NULL 허용(User.password: String?)
+// ---------------------------------------------
 
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["relationJoins"] // 관계 쿼리 성능 최적화
-  binaryTargets   = ["native", "linux-musl-arm64-openssl-3.0.x"]
+  provider = "prisma-client-js"
 }
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL") // 환경 변수에서 DB 연결 문자열 가져옴
+  url      = env("DATABASE_URL") // .env 파일의 DB 연결 문자열 사용
 }
 
-// 사용자 역할 정의 (RBAC: 역할 기반 접근 제어)
+// -----------------------------
+// Enums: 역할, 언어, 환경, Job/Log 상태 정의
+// -----------------------------
+
+// RBAC: 사용자 역할
 enum MemberRole {
-  ADMIN // 관리자: 모든 권한
-  MEMBER // 일반 사용자: 기본 권한
-  VIEWER // 읽기 전용: 제한된 권한
+  ADMIN
+  MEMBER
+  VIEWER
 }
 
-// 지원 언어 정의 (MVP: Node, Python)
+// 지원 언어
 enum Language {
-  NODE // Node.js 환경
-  PYTHON // Python 환경
+  NODE
+  PYTHON
 }
 
-// 지원 배포 환경 정의 (MVP: EC2)
+// MVP 배포 환경
 enum DeployEnvironment {
-  EC2 // AWS EC2 인스턴스
+  EC2
 }
 
-// 작업 타입 정의 (빌드/테스트/배포 작업 구분)
+// 작업 타입
 enum JobType {
-  BUILD // 빌드 작업
-  TEST // 테스트 작업 (Unit/E2E)
-  DEPLOYMENT // 배포 작업
+  BUILD
+  TEST
+  DEPLOYMENT
 }
 
-// 작업 상태 정의 (작업 라이프사이클 관리, 재시도 상태 포함)
+// 작업 상태 라이프사이클
 enum JobStatus {
-  pending // 대기 중
-  running // 실행 중
-  completed // 완료
-  failed // 실패
-  cancelled // 취소됨
+  pending
+  running
+  completed
+  failed
+  cancelled
 }
 
-// 로그 스트림 정의 (stdout/stderr 구분, S3 연계 시 사용)
+// 로그 스트림
 enum LogStream {
-  stdout // 표준 출력
-  stderr // 표준 에러
+  stdout
+  stderr
 }
 
-// 테스트 타입 정의 (테스트 작업 세분화)
+// 테스트 세분화
 enum TestType {
-  UNIT // 단위 테스트
-  E2E // End-to-End 테스트
+  UNIT
+  E2E
 }
 
-// 사용자 정보: 인증 및 프로젝트 소유
+// -----------------------------
+// Models
+// -----------------------------
+
 model User {
-  userID     String     @id @default(uuid()) @map("user_id") @db.Uuid // 기본 키, UUID로 고유성 보장
-  email      String     @unique @map("email") // 고유 이메일, 로그인 식별자
-  password   String     @map("password") // bcrypt로 암호화된 비밀번호
-  name       String     @map("name") // 사용자 표시 이름
-  memberRole MemberRole @default(MEMBER) @map("member_role") // 사용자 권한 역할, 기본 MEMBER
-  createdAt  DateTime   @default(now()) @map("created_at") @db.Timestamptz(6) // 계정 생성 시각, 감사/UX용
-  updatedAt  DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6) // 마지막 수정 시각, 변경 추적
+  userID     String     @id @default(uuid()) @map("user_id") @db.Uuid // UUID 기본키
+  email      String     @unique @map("email") // 로그인 식별자
+  password   String?    @map("password") // bcrypt 해시 저장, GitHub 계정은 NULL 허용
+  name       String     @map("name") // 표시 이름
+  memberRole MemberRole @default(MEMBER) @map("member_role") // 역할
+  createdAt  DateTime   @default(now()) @map("created_at") @db.Timestamptz(6) // 생성일
+  updatedAt  DateTime   @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정일
 
-  // 관계
-  projects      Project[] // 사용자가 소유한 프로젝트들 (일대다)
-  github        Github? // GitHub 계정 연결 정보 (일대일, 선택적)
-  refreshTokens RefreshToken[] // 리프레쉬 토큰
+  // Relations
+  projects      Project[]
+  github        Github?
+  refreshTokens RefreshToken[]
 
-  @@map("users") // DB 테이블 이름: users
+  @@index([createdAt]) // 최근 사용자 조회
+  @@map("users")
 }
 
 model RefreshToken {
   tokenId    String   @id @default(uuid()) @map("token_id") @db.Uuid
   userID     String   @map("user_id") @db.Uuid
-  token      String   @unique @map("token")
-  expiresAt  DateTime @map("expires_at")
-  lastUsedAt DateTime @default(now()) @map("last_used_at")
-  createdAt  DateTime @default(now()) @map("created_at")
+  token      String   @unique @map("token") // 리프레시 토큰 값
+  expiresAt  DateTime @map("expires_at") @db.Timestamptz(6)
+  lastUsedAt DateTime @default(now()) @map("last_used_at") @db.Timestamptz(6)
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
-  // 관계
   user User @relation(fields: [userID], references: [userID], onDelete: Cascade)
 
+  @@index([userID])
+  @@index([expiresAt])
+  @@index([createdAt])
   @@map("refresh_tokens")
 }
 
-// GitHub 앱 설치 정보: GitHub App 설치 및 인증
 model Github {
-  userID         String   @id @map("user_id") @db.Uuid // 기본 키, User.userID와 동일 (UUID)
-  installationId String   @unique @map("installation_id") // GitHub App 설치 ID
-  accessToken    String   @map("access_token") // GitHub App 액세스 토큰
-  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6) // 설치 시각
-  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6) // 마지막 업데이트 시각
+  userID      String  @id @map("user_id") @db.Uuid
+  githubID    String  @unique @map("github_id") // GitHub 계정 고유 ID
+  accessToken String? @map("access_token") // 선택적 토큰
 
-  // 관계
-  user User @relation(fields: [userID], references: [userID], onDelete: Cascade) // 사용자 삭제 시 연쇄 삭제
+  user User @relation(fields: [userID], references: [userID], onDelete: Cascade)
 
-  @@map("github") // DB 테이블 이름: github
+  @@map("github")
 }
 
-// 프로젝트-레포지토리 연결: 프로젝트와 GitHub 레포지토리 연결
-model ProjectRepository {
-  id             String   @id @default(uuid()) @map("id") @db.Uuid // 기본 키, UUID
-  projectID      String   @map("project_id") @db.Uuid // 소속 프로젝트 ID
-  repoFullName   String   @map("repo_full_name") // 레포지토리 전체 이름 (owner/repo)
-  selectedBranch String   @map("selected_branch") // 선택된 브랜치
-  isActive       Boolean  @default(true) @map("is_active") // 활성 상태
-  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정 시각
-
-  // 관계
-  project Project @relation(fields: [projectID], references: [projectID], onDelete: Cascade) // 프로젝트 삭제 시 연쇄 삭제
-
-  @@unique([projectID, repoFullName]) // 프로젝트당 레포지토리 고유성
-  @@index([projectID]) // 프로젝트별 조회 최적화
-  @@map("project_repositories") // DB 테이블 이름: project_repositories
-}
-
-// 프로젝트: 사용자별 CI/CD 작업 단위
 model Project {
-  projectID  String   @id @default(uuid()) @map("project_id") @db.Uuid // 기본 키, UUID
-  userID     String   @map("user_id") @db.Uuid // 소유자 ID (UUID 참조)
-  name       String   @map("name") // 프로젝트 표시 이름
-  webhookUrl String?  @unique @map("webhook_url") // GitHub webhook URL (선택적, 고유)
+  projectID  String   @id @default(uuid()) @map("project_id") @db.Uuid // 프로젝트 ID (UUID)
+  userID     String   @map("user_id") @db.Uuid // 소유 사용자 ID (FK)
+  name       String   @map("name") // 프로젝트명 (사용자별 유일)
+  webhookUrl String?  @unique @map("webhook_url") // GitHub webhook (전역 유일, NULL 허용)
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
   updatedAt  DateTime @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정 시각
 
-  // 관계
-  user         User                @relation(fields: [userID], references: [userID], onDelete: Cascade) // 사용자 삭제 시 연쇄 삭제
+  // Relations
+  user         User          @relation(fields: [userID], references: [userID], onDelete: Cascade) // 사용자 삭제 시 연쇄 삭제
   pipelines    Pipeline[] // 프로젝트에 속한 파이프라인들
-  environments Environment[] // 프로젝트 환경 설정들
-  repositories ProjectRepository[] // 프로젝트에 연결된 레포지토리들
+  environments Environment[] // 프로젝트 환경들
 
-  @@map("projects") // DB 테이블 이름: projects
+  @@unique([userID, name]) // 같은 사용자 내 동일 이름 금지(GitHub 리포지토리 네이밍과 유사 규칙)
+  @@index([userID]) // 사용자별 프로젝트 조회 최적화
+  @@index([createdAt]) // 최신순 정렬/조회 최적화
+  @@map("projects")
 }
 
-// 환경 설정: 언어, 배포 환경, 환경 변수, 인증 정보
 model Environment {
-  environmentID    String            @id @default(uuid()) @map("environment_id") @db.Uuid // 기본 키, UUID
-  projectID        String            @map("project_id") @db.Uuid // 소속 프로젝트 ID (UUID 참조)
-  language         Language          @map("language") // 프로그래밍 언어 (Node/Python)
-  deployEnv        DeployEnvironment @map("deploy_environment") // 배포 환경 (EC2)
-  envVariables     Json?             @map("env_variables") // 환경 변수 (JSON, 예: {"NODE_ENV": "production"})
-  credentials      Json?             @map("credentials") // 인증 정보 (JSON, 암호화 권장)
-  deploymentTarget String?           @map("deployment_target") // 배포 대상 (IP, 도메인)
-  deploymentPath   String?           @map("deployment_path") // 서버 내 배포 경로
-  servicePort      Int?              @map("service_port") // 서비스 실행 포트
-  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정 시각
+  environmentID    String            @id @default(uuid()) @map("environment_id") @db.Uuid
+  projectID        String            @map("project_id") @db.Uuid
+  language         Language          @map("language")
+  deployEnv        DeployEnvironment @map("deploy_environment")
+  envVariables     Json?             @map("env_variables")
+  credentials      Json?             @map("credentials")
+  deploymentTarget String?           @map("deployment_target")
+  deploymentPath   String?           @map("deployment_path")
+  servicePort      Int?              @map("service_port")
+  createdAt        DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime          @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  // 관계
-  project Project @relation(fields: [projectID], references: [projectID], onDelete: Cascade) // 프로젝트 삭제 시 연쇄 삭제
+  project Project @relation(fields: [projectID], references: [projectID], onDelete: Cascade)
 
-  @@map("environments") // DB 테이블 이름: environments
+  @@index([projectID])
+  @@index([createdAt])
+  @@map("environments")
 }
 
-// 파이프라인: 빌드/테스트/배포 워크플로우 정의
 model Pipeline {
-  pipelineID   String   @id @default(uuid()) @map("pipeline_id") @db.Uuid // 기본 키, UUID
-  projectID    String   @map("project_id") @db.Uuid // 소속 프로젝트 ID (UUID 참조)
-  name         String   @map("name") // 파이프라인 이름
-  version      Int      @default(1) @map("version") // 버전 관리, 기본 1
-  active       Boolean  @default(true) @map("active") // 활성 여부
-  owner        String?  @map("owner") // 소유자 정보 (선택적, 사용자 이름/ID)
-  pipelineSpec Json     @map("pipeline_spec") // YAML/Shell 또는 PaB 설정 (JSON)
-  isBlockBased Boolean  @default(false) @map("is_block_based") // PaB 방식 여부
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6) // 수정 시각
+  pipelineID     String   @id @default(uuid()) @map("pipeline_id") @db.Uuid
+  projectID      String   @map("project_id") @db.Uuid
+  name           String   @map("name")
+  version        Int      @default(1) @map("version") // 버전 관리
+  active         Boolean  @default(true) @map("active")
+  owner          String?  @map("owner")
+  pipelineSpec   Json     @map("pipeline_spec") // 원본 pipeline JSON
+  isBlockBased   Boolean  @default(false) @map("is_block_based")
+  originalSpec   String?  @map("original_spec") @db.Text // 원본 YAML/JSON 저장
+  normalizedSpec Json?    @map("normalized_spec") // 정규화된 JSON
+  specHash       String?  @map("spec_hash") @db.VarChar(64) // SHA-256 해시
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  // 관계
-  project Project       @relation(fields: [projectID], references: [projectID], onDelete: Cascade) // 프로젝트 삭제 시 연쇄 삭제
-  runs    PipelineRun[] // 파이프라인 실행 인스턴스들
+  project Project       @relation(fields: [projectID], references: [projectID], onDelete: Cascade)
+  runs    PipelineRun[]
 
-  @@unique([name, version]) // 이름과 버전으로 고유성 보장
-  @@index([owner]) // 소유자 기반 조회 최적화
-  @@index([projectID]) // 프로젝트별 조회 최적화
-  @@map("pipelines") // DB 테이블 이름: pipelines
+  @@unique([projectID, name, version])
+  @@index([owner])
+  @@index([projectID])
+  @@index([specHash])
+  @@index([createdAt])
+  @@map("pipelines")
 }
 
-// 파이프라인 실행 인스턴스: 특정 시점의 파이프라인 실행
 model PipelineRun {
-  id              String    @id @default(uuid()) @map("id") @db.Uuid // 기본 키, UUID
-  pipelineID      String    @map("pipeline_id") @db.Uuid // 소속 파이프라인 ID (UUID 참조)
-  pipelineVersion Int       @map("pipeline_version") // 실행 시점의 파이프라인 버전
-  status          JobStatus @map("status") // 실행 상태
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  queuedAt        DateTime? @map("queued_at") @db.Timestamptz(6) // 대기 시작 시각
-  startedAt       DateTime? @map("started_at") @db.Timestamptz(6) // 시작 시각
-  finishedAt      DateTime? @map("finished_at") @db.Timestamptz(6) // 완료 시각
-  exitCode        Int?      @map("exit_code") // 종료 코드 (오류 분석)
-  owner           String?   @map("owner") // 실행 요청자
-  agent           String?   @map("agent") // 실행 에이전트 (서버/컨테이너)
-  containerImage  String?   @map("container_image") // 컨테이너 이미지
-  trigger         String?   @map("trigger") // 트리거 정보 (webhook, manual)
-  labels          Json?     @map("labels") // 레이블 (메타데이터)
-  metadata        Json?     @map("metadata") // 추가 메타데이터
-  externalRunKey  String?   @unique @map("external_run_key") // 외부 실행 키 (고유)
+  id              String    @id @default(uuid()) @map("id") @db.Uuid
+  pipelineID      String    @map("pipeline_id") @db.Uuid
+  pipelineVersion Int       @map("pipeline_version")
+  status          JobStatus @map("status")
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  queuedAt        DateTime? @map("queued_at") @db.Timestamptz(6)
+  startedAt       DateTime? @map("started_at") @db.Timestamptz(6)
+  finishedAt      DateTime? @map("finished_at") @db.Timestamptz(6)
+  exitCode        Int?      @map("exit_code")
+  owner           String?   @map("owner")
+  agent           String?   @map("agent")
+  containerImage  String?   @map("container_image")
+  trigger         String?   @map("trigger")
+  labels          Json?     @map("labels")
+  metadata        Json?     @map("metadata")
+  externalRunKey  String?   @unique @map("external_run_key")
+  idempotencyKey  String?   @unique @map("idempotency_key") // 멱등성 보장
 
-  // 관계
-  pipeline Pipeline @relation(fields: [pipelineID], references: [pipelineID], onDelete: Restrict) // 실행 중 삭제 방지
-  jobs     Job[] // 실행에 포함된 작업들
+  pipeline Pipeline @relation(fields: [pipelineID], references: [pipelineID], onDelete: Restrict)
+  jobs     Job[]
 
-  @@index([pipelineID, createdAt(sort: Desc)]) // 파이프라인별 최근 실행 조회 최적화
-  @@index([status, createdAt(sort: Desc)]) // 상태별 최근 실행 조회 최적화
-  @@map("pipeline_runs") // DB 테이블 이름: pipeline_runs
+  @@index([pipelineID, createdAt])
+  @@index([status, createdAt])
+  @@index([createdAt])
+  @@map("pipeline_runs")
 }
 
-// 개별 작업: 빌드/테스트/배포 등 구체적 작업 단위
 model Job {
-  id             String    @id @default(uuid()) @map("id") @db.Uuid // 실제 삽입할 때 ULID 생성
-  runID          String    @map("run_id") @db.Uuid // 소속 실행 ID (UUID 참조)
-  name           String    @map("name") // 작업 이름
-  type           JobType   @map("type") // 작업 타입 (BUILD/TEST/DEPLOYMENT)
-  testType       TestType? @map("test_type") // 테스트 타입 (TEST일 때 사용)
-  status         JobStatus @map("status") // 작업 상태 (재시도 상태 포함)
-  attemptCurrent Int       @default(0) @map("attempt_current") // 현재 재시도 횟수
-  attemptMax     Int       @default(3) @map("attempt_max") // 최대 재시도 횟수
-  exitCode       Int?      @map("exit_code") // 종료 코드
-  envVariables   Json?     @map("env_variables") // 작업별 환경 변수 (런타임 주입)
-  s3ArtifactUrl  String?   @map("s3_artifact_url") // S3 결과물 URL
-  targetUrl      String?   @map("target_url") // 배포 대상 URL (DEPLOYMENT용)
-  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각
-  queuedAt       DateTime? @map("queued_at") @db.Timestamptz(6) // 대기 시작
-  startedAt      DateTime? @map("started_at") @db.Timestamptz(6) // 시작
-  finishedAt     DateTime? @map("finished_at") @db.Timestamptz(6) // 완료
-  owner          String?   @map("owner") // 소유자
-  agent          String?   @map("agent") // 에이전트
-  containerImage String?   @map("container_image") // 컨테이너 이미지
-  command        String?   @map("command") // 실행 명령어
-  inputs         Json?     @map("inputs") // 입력 데이터
-  outputs        Json?     @map("outputs") // 출력 결과
-  externalJobKey String?   @unique @map("external_job_key") // 외부 작업 키
+  id             String    @id @default(uuid()) @map("id") @db.Uuid
+  runID          String    @map("run_id") @db.Uuid
+  name           String    @map("name")
+  type           JobType   @map("type")
+  testType       TestType? @map("test_type")
+  status         JobStatus @map("status")
+  attemptCurrent Int       @default(0) @map("attempt_current")
+  attemptMax     Int       @default(3) @map("attempt_max")
+  exitCode       Int?      @map("exit_code")
+  envVariables   Json?     @map("env_variables")
+  s3ArtifactUrl  String?   @map("s3_artifact_url")
+  targetUrl      String?   @map("target_url")
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  queuedAt       DateTime? @map("queued_at") @db.Timestamptz(6)
+  startedAt      DateTime? @map("started_at") @db.Timestamptz(6)
+  finishedAt     DateTime? @map("finished_at") @db.Timestamptz(6)
+  owner          String?   @map("owner")
+  agent          String?   @map("agent")
+  containerImage String?   @map("container_image")
+  command        String?   @map("command")
+  inputs         Json?     @map("inputs")
+  outputs        Json?     @map("outputs")
+  externalJobKey String?   @unique @map("external_job_key")
 
-  // 관계
-  run          PipelineRun      @relation(fields: [runID], references: [id], onDelete: Cascade) // 실행 삭제 시 연쇄 삭제
-  statusEvents JobStatusEvent[] // 상태 변화 이벤트
-  errors       JobError[] // 실행 오류
-  logs         Log[] // 실행 로그
+  run          PipelineRun      @relation(fields: [runID], references: [id], onDelete: Cascade)
+  statusEvents JobStatusEvent[]
+  errors       JobError[]
+  logs         Log[]
 
-  @@unique([runID, name]) // 실행 내 작업 이름 고유성
-  @@index([runID, createdAt(sort: Desc)]) // 실행별 최근 작업 조회
-  @@index([status, createdAt(sort: Desc)]) // 상태별 최근 작업 조회
-  @@index([type, createdAt(sort: Desc)]) // 타입별 최근 작업 조회
-  @@index([agent]) // 에이전트별 조회
-  @@map("jobs") // DB 테이블 이름: jobs
+  @@unique([runID, name])
+  @@index([runID, createdAt])
+  @@index([status, createdAt])
+  @@index([type, createdAt])
+  @@index([agent])
+  @@index([createdAt])
+  @@map("jobs")
 }
 
-// 작업 상태 이벤트: 상태 변화 추적
 model JobStatusEvent {
-  id         String     @id @default(uuid()) @map("id") @db.Uuid // 기본 키, UUID
-  jobID      String     @map("job_id") @db.Uuid // 소속 작업 ID (ULID 참조)
-  fromStatus JobStatus? @map("from_status") // 이전 상태 (선택적)
-  toStatus   JobStatus  @map("to_status") // 현재 상태
-  reason     String?    @map("reason") // 상태 변경 사유
-  data       Json?      @map("data") // 추가 데이터
-  at         DateTime   @default(now()) @map("at") @db.Timestamptz(6) // 이벤트 시각
+  id         String     @id @default(uuid()) @map("id") @db.Uuid
+  jobID      String     @map("job_id") @db.Uuid
+  fromStatus JobStatus? @map("from_status")
+  toStatus   JobStatus  @map("to_status")
+  reason     String?    @map("reason")
+  data       Json?      @map("data")
+  at         DateTime   @default(now()) @map("at") @db.Timestamptz(6)
 
-  // 관계
-  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade) // 작업 삭제 시 연쇄 삭제
+  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
 
-  @@index([jobID, at(sort: Desc)]) // 작업별 최근 이벤트 조회
-  @@map("job_status_events") // DB 테이블 이름: job_status_events
+  @@index([jobID, at])
+  @@map("job_status_events")
 }
 
-// 작업 오류: 실행 중 발생한 오류 기록
 model JobError {
-  id         String   @id @default(uuid()) @map("id") @db.Uuid // 기본 키, UUID
-  jobID      String   @map("job_id") @db.Uuid // 소속 작업 ID (ULID 참조)
-  attemptNo  Int      @map("attempt_no") // 재시도 번호
-  occurredAt DateTime @default(now()) @map("occurred_at") @db.Timestamptz(6) // 발생 시각
-  errorType  String?  @map("error_type") // 오류 유형
-  message    String?  @map("message") @db.VarChar(4096) // 오류 메시지
-  stacktrace String?  @map("stacktrace") @db.VarChar(8192) // 스택 트레이스
-  context    Json?    @map("context") // 맥락 데이터
-  dedupeKey  String?  @unique @map("dedupe_key") // 중복 제거 키
+  id         String   @id @default(uuid()) @map("id") @db.Uuid
+  jobID      String   @map("job_id") @db.Uuid
+  attemptNo  Int      @map("attempt_no")
+  occurredAt DateTime @default(now()) @map("occurred_at") @db.Timestamptz(6)
+  errorType  String?  @map("error_type")
+  message    String?  @map("message") @db.VarChar(4096)
+  stacktrace String?  @map("stacktrace") @db.VarChar(8192)
+  context    Json?    @map("context")
+  dedupeKey  String?  @map("dedupe_key")
 
-  // 관계
-  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade) // 작업 삭제 시 연쇄 삭제
+  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
 
-  @@index([jobID, attemptNo]) // 작업/재시도별 조회
-  @@index([occurredAt(sort: Desc)]) // 최근 오류 조회
-  @@index([errorType]) // 오류 타입별 조회
-  @@map("job_errors") // DB 테이블 이름: job_errors
+  @@unique([jobID, dedupeKey]) // Job별 오류 중복 제거
+  @@index([jobID, attemptNo])
+  @@index([occurredAt])
+  @@index([errorType])
+  @@map("job_errors")
 }
 
-// 로그: 작업 실행 중 생성되는 로그 정보
 model Log {
-  logID         String    @id @default(uuid()) @map("log_id") @db.Uuid // 실제 삽입할 때 ULID 생성
-  jobID         String    @map("job_id") @db.Uuid // 소속 작업 ID (ULID 참조)
-  attemptNo     Int       @map("attempt_no") // 재시도 번호
-  stream        LogStream @map("stream") // 로그 스트림 (stdout/stderr)
-  content       String?   @map("content") // 내부 로그 내용 (짧은 로그)
-  storageBucket String?   @map("storage_bucket") // S3 버킷 (긴 로그)
+  logID         String    @id @default(uuid()) @map("log_id") @db.Uuid
+  jobID         String    @map("job_id") @db.Uuid
+  attemptNo     Int       @map("attempt_no")
+  stream        LogStream @map("stream")
+  content       String?   @map("content") // 짧은 로그만 저장
+  storageBucket String?   @map("storage_bucket") // S3 버킷
   storageKey    String?   @map("storage_key") // S3 키
-  sizeBytes     BigInt?   @map("size_bytes") @db.BigInt // 로그 크기 (바이트)
-  contentType   String?   @map("content_type") // 콘텐츠 타입 (e.g., text/plain)
-  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6) // 생성 시각 (TTL 기준)
+  sizeBytes     BigInt?   @map("size_bytes") @db.BigInt
+  contentType   String?   @map("content_type")
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
 
-  // 관계
-  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade) // 작업 삭제 시 연쇄 삭제
+  job Job @relation(fields: [jobID], references: [id], onDelete: Cascade)
 
-  @@unique([jobID, attemptNo, stream]) // 작업/재시도/스트림별 고유성
-  @@index([jobID, attemptNo]) // 작업/재시도별 조회
-  @@index([createdAt(sort: Desc)]) // 최근 로그 조회 (TTL 관리)
-  @@map("logs") // DB 테이블 이름: logs
+  @@unique([jobID, attemptNo, stream]) // Job/시도/스트림별 1행만
+  @@index([jobID, attemptNo])
+  @@index([createdAt])
+  @@map("logs")
+}
+
+model Outbox {
+  id          BigInt    @id @default(autoincrement()) @map("id")
+  eventType   String    @map("event_type") // 이벤트 타입
+  payload     Json      @map("payload") // 이벤트 본문
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  publishedAt DateTime? @map("published_at") @db.Timestamptz(6) // 발행 시각
+  attempts    Int       @default(0) @map("attempts") // 재시도 횟수
+
+  @@index([publishedAt])
+  @@index([createdAt])
+  @@map("outbox")
 }


### PR DESCRIPTION
### PR 내용 요약
- DB 스키마를 최신 설계 원칙에 맞게 업데이트했습니다.
- User 테이블
  - password 필드를 nullable로 변경 → GitHub OAuth 사용자도 계정 생성 가능
- Project 테이블
  - 동일 사용자(user_id) 내에서 같은 이름(name)의 프로젝트를 생성할 수 없도록 Unique 제약 추가
- Pipeline 테이블
  - 파이프라인 스펙 관련 컬럼(original_spec, normalized_spec, spec_hash) 추가
  - spec_hash에 인덱스 부여 → 버전 관리 및 무결성 확인 목적spec_hash) 추가
- PipelineRun 테이블
  - idempotency_key 컬럼 추가 및 Unique 제약 → 중복 실행 방지 목적
- GithubInstallation 테이블
  - 기존 Github → GithubInstallation으로 테이블명 변경
  - installationId를 통해 GitHub App 설치 정보를 관리
  - 1명의 사용자(User)가 여러 Installation을 가질 수 있도록 모델 확장 (multi-installation 지원)
  - github_id 컬럼 추가 및 Unique 제약 적용
- Outbox 테이블
  - 이벤트 발행을 위한 Outbox 테이블 신규 생성

---

### 변경 배경
- 프로젝트 전반에 걸쳐 ID, 시간 정렬, 멱등성 보장, 외부 이벤트 처리 등 핵심 원칙을 일관되게 적용하기 위함.
- GitHub App과 Repository 연결을 명확히 분리하여 관리 편의성 확보.
- Outbox 패턴으로 외부 발행 이벤트의 신뢰성을 강화.

---

### 영향 범위
- DB 마이그레이션 필수: 개발/테스트 환경 DB 리셋 및 재적용 필요 (npx prisma migrate reset)
- API 레벨 영향:
  - User 생성 시 password 없이도 계정 생성 가능
  - Project 생성 API에서 동일 이름 생성 시 에러 반환 예상
  - GitHub 토큰 저장 정책은 ? (nullable) 상태로 보류

---

### 점검 항목
- npx prisma migrate dev 실행 후 DB 스키마 정상 반영 확인
- 기존 API 코드에서 FK/Unique 제약 조건 충돌 없는지 확인
- Outbox 이벤트 발행 로직 적용 시 추가 테스트 필요
- GitHub accessToken 저장 여부 최종 결정 필요
- Project 생성 API에서 중복 이름 제약 에러 반환 확인
- GitHub OAuth 계정 생성 시 password 없이 정상 등록 확인