### PR TITLE
feat: 웹훅 트리거 파이프라인 실행

### DIFF
--- a/src/pipelines/services/pipeline.service.ts
+++ b/src/pipelines/services/pipeline.service.ts
@@ -176,4 +176,154 @@ export class PipelineService {
 
     return run;
   }
+
+  /**
+   * 파이프라인 자동 실행 (웹훅 트리거용)
+   */
+  async startPipelineExecution(runId: string) {
+    // 백그라운드에서 실행하여 웹훅 응답 지연 방지
+    setImmediate(() => {
+      this.executePipeline(runId).catch((error) => {
+        console.error(`[Pipeline] Execution failed for run ${runId}:`, error);
+      });
+    });
+  }
+
+  /**
+   * 파이프라인 실제 실행 로직
+   */
+  private async executePipeline(runId: string) {
+    try {
+      // 실행 시작 상태로 변경
+      const run = await this.prisma.pipelineRun.update({
+        where: { id: runId },
+        data: {
+          status: 'running' as never,
+          startedAt: new Date(),
+        },
+        include: {
+          pipeline: true,
+        },
+      });
+
+      console.log(`[Pipeline] Starting execution for run ${runId}`);
+
+      // 파이프라인 스펙 파싱
+      const pipelineSpec = run.pipeline.pipelineSpec as any;
+      const jobs = this.parseJobsFromPipelineSpec(pipelineSpec);
+
+      // Job 순차 실행
+      for (const jobConfig of jobs) {
+        await this.executeJob(runId, run.pipelineID, jobConfig);
+      }
+
+      // 성공 상태로 변경
+      await this.prisma.pipelineRun.update({
+        where: { id: runId },
+        data: {
+          status: 'success' as never,
+          finishedAt: new Date(),
+          exitCode: 0,
+        },
+      });
+
+      console.log(`[Pipeline] Execution completed successfully for run ${runId}`);
+
+    } catch (error) {
+      // 실패 상태로 변경
+      await this.prisma.pipelineRun.update({
+        where: { id: runId },
+        data: {
+          status: 'failed' as never,
+          finishedAt: new Date(),
+          exitCode: 1,
+        },
+      });
+
+      console.error(`[Pipeline] Execution failed for run ${runId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 파이프라인 스펙에서 Job 목록 추출
+   */
+  private parseJobsFromPipelineSpec(spec: any): Array<{
+    name: string;
+    type: string;
+    commands: string[];
+  }> {
+    const jobs: Array<{ name: string; type: string; commands: string[] }> = [];
+
+    // build 단계
+    if (spec.build) {
+      jobs.push({
+        name: 'build',
+        type: 'BUILD',
+        commands: Array.isArray(spec.build) ? spec.build : [spec.build],
+      });
+    }
+
+    // test 단계
+    if (spec.test) {
+      jobs.push({
+        name: 'test',
+        type: 'TEST',
+        commands: Array.isArray(spec.test) ? spec.test : [spec.test],
+      });
+    }
+
+    // deploy 단계
+    if (spec.deploy) {
+      jobs.push({
+        name: 'deploy',
+        type: 'DEPLOYMENT',
+        commands: Array.isArray(spec.deploy) ? spec.deploy : [spec.deploy],
+      });
+    }
+
+    return jobs;
+  }
+
+  /**
+   * 개별 Job 실행 시뮬레이션
+   */
+  private async executeJob(runId: string, pipelineId: string, jobConfig: {
+    name: string;
+    type: string;
+    commands: string[];
+  }) {
+    try {
+      console.log(`[Job] Starting ${jobConfig.name} (${jobConfig.type}) for run ${runId}`);
+      
+      // 실제 Job 생성은 생략하고 실행만 시뮬레이션
+      await this.simulateJobExecution(jobConfig);
+
+      console.log(`[Job] Completed ${jobConfig.name} for run ${runId}`);
+
+    } catch (error) {
+      console.error(`[Job] Failed ${jobConfig.name} for run ${runId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Job 실행 시뮬레이션 (추후 실제 실행 로직으로 교체)
+   */
+  private async simulateJobExecution(jobConfig: {
+    name: string;
+    type: string;
+    commands: string[];
+  }) {
+    console.log(`[Job Simulation] Executing ${jobConfig.name}:`, jobConfig.commands);
+    
+    // 실행 시간 시뮬레이션 (2-5초)
+    const executionTime = 2000 + Math.random() * 3000;
+    await new Promise(resolve => setTimeout(resolve, executionTime));
+    
+    // 5% 확률로 실패 시뮬레이션
+    if (Math.random() < 0.05) {
+      throw new Error(`Simulated failure in ${jobConfig.name} job`);
+    }
+  }
 }

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ProjectService } from './services/project.service';
 import { ProjectController } from './controllers/project.controller';
 import { GithubService } from './services/github.service';
+import { PipelinesModule } from '../pipelines/pipelines.module';
 
 @Module({
-  imports: [],
+  imports: [PipelinesModule],
   exports: [ProjectService, GithubService],
   providers: [ProjectService, GithubService],
   controllers: [ProjectController],

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,11 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ProjectService } from './services/project.service';
 import { ProjectController } from './controllers/project.controller';
 import { GithubService } from './services/github.service';
 import { PipelinesModule } from '../pipelines/pipelines.module';
 
 @Module({
-  imports: [PipelinesModule],
+  imports: [forwardRef(() => PipelinesModule)],
   exports: [ProjectService, GithubService],
   providers: [ProjectService, GithubService],
   controllers: [ProjectController],

--- a/src/projects/services/project.service.ts
+++ b/src/projects/services/project.service.ts
@@ -5,6 +5,8 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  Inject,
+  forwardRef,
 } from '@nestjs/common';
 import { PrismaService } from '../../database/prisma.service';
 import { GithubService } from './github.service';
@@ -17,6 +19,7 @@ export class ProjectService {
     private prisma: PrismaService,
     private githubService: GithubService,
     private jwtService: JwtService,
+    @Inject(forwardRef(() => PipelineService))
     private pipelineService: PipelineService,
   ) {}
 
@@ -405,8 +408,10 @@ export class ProjectService {
 
     // 웹훅 트리거인 경우 자동으로 파이프라인 실행
     if (buildInfo.trigger.startsWith('webhook:')) {
-      console.log(`[Webhook] Auto-triggering pipeline execution for run ${run.id}`);
-      this.pipelineService.startPipelineExecution(run.id);
+      console.log(
+        `[Webhook] Auto-triggering pipeline execution for run ${run.id}`,
+      );
+      void this.pipelineService.startPipelineExecution(run.id);
     }
 
     return run;


### PR DESCRIPTION
  1. GitHub 웹훅 수신 →
  webhook.controller.ts:handlePushEvent
  2. 프로젝트 매칭 → 브랜치 일치하는 프로젝트
  필터링
  3. 빌드 레코드 생성 →
  project.service.ts:createBuildRecord
  4. 🆕 자동 실행 트리거 →
  trigger.startsWith('webhook:') 조건으로 자동
   실행
  5. 파이프라인 실행 →
  pipeline.service.ts:startPipelineExecution
    - pending → running → success/failed 상태

  변화
    - YAML 스펙 파싱 (build/test/deploy)
    - Job 순차 실행 시뮬레이션

  **주요 변경사항**
  - PipelineService: startPipelineExecution()
  메서드 추가
  - ProjectService: 웹훅 트리거시 자동 실행
  로직 추가
  - Module 연결: ProjectsModule에서
  PipelinesModule import